### PR TITLE
fix: correct Content-Length in hello.sh

### DIFF
--- a/runtimes/operating-systems/debian/12.6/project/hello.sh
+++ b/runtimes/operating-systems/debian/12.6/project/hello.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+body="Hello, World!"
+
 while :; do
-    { echo -ne "HTTP/1.1 200 OK\r\nContent-Length: $(echo -n "Hello, World!")\r\n\r\nHello, World!"; } | nc -l -p 8080 -q 1
+    {
+        printf 'HTTP/1.1 200 OK\r\n'
+        printf 'Content-Length: %d\r\n' "${#body}"
+        printf '\r\n'
+        printf '%s' "$body"
+    } | nc -l -p 8080 -q 1
 done

--- a/runtimes/operating-systems/ubuntu-cuda/24.04/project/hello.sh
+++ b/runtimes/operating-systems/ubuntu-cuda/24.04/project/hello.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+body="Hello, World!"
+
 while :; do
-    { echo -ne "HTTP/1.1 200 OK\r\nContent-Length: $(echo -n "Hello, World!")\r\n\r\nHello, World!"; } | nc -l -p 8080 -q 1
+    {
+        printf 'HTTP/1.1 200 OK\r\n'
+        printf 'Content-Length: %d\r\n' "${#body}"
+        printf '\r\n'
+        printf '%s' "$body"
+    } | nc -l -p 8080 -q 1
 done

--- a/runtimes/operating-systems/ubuntu/24.04/project/hello.sh
+++ b/runtimes/operating-systems/ubuntu/24.04/project/hello.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+body="Hello, World!"
+
 while :; do
-    { echo -ne "HTTP/1.1 200 OK\r\nContent-Length: $(echo -n "Hello, World!")\r\n\r\nHello, World!"; } | nc -l -p 8080 -q 1
+    {
+        printf 'HTTP/1.1 200 OK\r\n'
+        printf 'Content-Length: %d\r\n' "${#body}"
+        printf '\r\n'
+        printf '%s' "$body"
+    } | nc -l -p 8080 -q 1
 done


### PR DESCRIPTION
Compute Content-Length from the response body length instead of embedding the body string in the header.

Also switch response output to printf for predictable escaping behavior.