### PR TITLE
fix: configure fastgpt code-server defaults

### DIFF
--- a/base-images/frameworks/sandbox/fastgpt/Dockerfile
+++ b/base-images/frameworks/sandbox/fastgpt/Dockerfile
@@ -29,7 +29,7 @@ ENV CODEX_GATEWAY_MAX_SESSIONS=12
 ENV CODEX_GATEWAY_SESSION_TTL_MS=1800000
 ENV CODEX_GATEWAY_SESSION_SWEEP_INTERVAL_MS=60000
 ENV CODE_SERVER_ENABLED=false
-ENV CODE_SERVER_BIND_ADDR=0.0.0.0:8080
+ENV CODE_SERVER_BIND_ADDR=0.0.0.0:1318
 
 COPY --from=codex-gateway /usr/local/bin/codex-gateway /usr/local/bin/codex-gateway
 
@@ -46,4 +46,4 @@ RUN chmod +x /build.sh \
     rm -f /build.sh && \
     rm -rf /tmp/codex-gateway-service /tmp/code-server-service
 
-EXPOSE 1317 8080
+EXPOSE 1317 1318

--- a/base-images/frameworks/sandbox/fastgpt/code-server/finish
+++ b/base-images/frameworks/sandbox/fastgpt/code-server/finish
@@ -7,6 +7,11 @@ if [ "$EXIT_CODE" = "101" ]; then
     exit 125
 fi
 
+if [ "$EXIT_CODE" = "102" ]; then
+    echo "code-server stopped because DEVBOX_JWT_SECRET is missing. Preventing s6 restart."
+    exit 125
+fi
+
 if [ "$EXIT_CODE" = "111" ]; then
     echo "code-server stopped because required files were not installed correctly. Preventing s6 restart."
     exit 125

--- a/base-images/frameworks/sandbox/fastgpt/code-server/run
+++ b/base-images/frameworks/sandbox/fastgpt/code-server/run
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DEFAULT_DEVBOX_USER=${DEFAULT_DEVBOX_USER:-devbox}
 CODE_SERVER_ENABLED_VALUE=${ENABLE_CODE_SERVER:-${CODE_SERVER_ENABLED:-false}}
-CODE_SERVER_BIND_ADDR=${CODE_SERVER_BIND_ADDR:-0.0.0.0:8080}
+CODE_SERVER_BIND_ADDR=${CODE_SERVER_BIND_ADDR:-0.0.0.0:1318}
 
 case "$(printf '%s' "$CODE_SERVER_ENABLED_VALUE" | tr '[:upper:]' '[:lower:]')" in
     1 | true | yes | on | enabled)

--- a/base-images/frameworks/sandbox/fastgpt/code-server/run
+++ b/base-images/frameworks/sandbox/fastgpt/code-server/run
@@ -4,6 +4,7 @@ set -euo pipefail
 DEFAULT_DEVBOX_USER=${DEFAULT_DEVBOX_USER:-devbox}
 CODE_SERVER_ENABLED_VALUE=${ENABLE_CODE_SERVER:-${CODE_SERVER_ENABLED:-false}}
 CODE_SERVER_BIND_ADDR=${CODE_SERVER_BIND_ADDR:-0.0.0.0:1318}
+CODE_SERVER_PASSWORD=${DEVBOX_JWT_SECRET:-}
 
 case "$(printf '%s' "$CODE_SERVER_ENABLED_VALUE" | tr '[:upper:]' '[:lower:]')" in
     1 | true | yes | on | enabled)
@@ -13,6 +14,11 @@ case "$(printf '%s' "$CODE_SERVER_ENABLED_VALUE" | tr '[:upper:]' '[:lower:]')" 
         exit 101
         ;;
 esac
+
+if [ -z "$CODE_SERVER_PASSWORD" ]; then
+    echo "code-server requires DEVBOX_JWT_SECRET to be set as its password." >&2
+    exit 102
+fi
 
 DEVBOX_HOME="$(getent passwd "$DEFAULT_DEVBOX_USER" | cut -d: -f6 || true)"
 if [ -z "$DEVBOX_HOME" ]; then
@@ -24,6 +30,7 @@ WORKSPACE_DIR=${CODE_SERVER_WORKSPACE:-${CODEX_GATEWAY_CWD:-${DEVBOX_HOME}/works
 export HOME="$DEVBOX_HOME"
 export USER="$DEFAULT_DEVBOX_USER"
 export LOGNAME="$DEFAULT_DEVBOX_USER"
+export PASSWORD="$CODE_SERVER_PASSWORD"
 
 mkdir -p "$WORKSPACE_DIR"
 chown "$DEFAULT_DEVBOX_USER:$DEFAULT_DEVBOX_USER" "$WORKSPACE_DIR" || true
@@ -41,5 +48,6 @@ exec s6-setuidgid "$DEFAULT_DEVBOX_USER" code-server \
        --disable-workspace-trust \
        --disable-getting-started-override \
        --app-name "Skills" \
+       --auth password \
        --bind-addr "$CODE_SERVER_BIND_ADDR" \
        "$WORKSPACE_DIR"

--- a/tests/runtime-conformance/README.md
+++ b/tests/runtime-conformance/README.md
@@ -54,4 +54,4 @@ Runtime-specific checks:
 | `frameworks/nginx/1.22.1` | Nginx 1.22.1, config test, `/tmp/nginx-devbox` runtime paths, no distro default include pollution, root/devbox entrypoint order |
 | `frameworks/openclaw/latest` | Node 22, OpenClaw, Clawhub, Bun, npm mirror for `zh_CN`, safe `.env.example`, root/devbox entrypoint order |
 | `frameworks/sandbox/v1` | workspace ownership, codex-gateway, Codex CLI, Node/npm, Python/pip, kubectl, helm, bun, ripgrep, bubblewrap, npm/pip mirrors for `zh_CN` |
-| `frameworks/sandbox/fastgpt` | `v1` checks plus code-server binary, default `CODE_SERVER_BIND_ADDR=0.0.0.0:1318`, and s6 service registration |
+| `frameworks/sandbox/fastgpt` | `v1` checks plus code-server binary, default `CODE_SERVER_BIND_ADDR=0.0.0.0:1318`, `DEVBOX_JWT_SECRET` password auth, and s6 service registration |

--- a/tests/runtime-conformance/README.md
+++ b/tests/runtime-conformance/README.md
@@ -54,4 +54,4 @@ Runtime-specific checks:
 | `frameworks/nginx/1.22.1` | Nginx 1.22.1, config test, `/tmp/nginx-devbox` runtime paths, no distro default include pollution, root/devbox entrypoint order |
 | `frameworks/openclaw/latest` | Node 22, OpenClaw, Clawhub, Bun, npm mirror for `zh_CN`, safe `.env.example`, root/devbox entrypoint order |
 | `frameworks/sandbox/v1` | workspace ownership, codex-gateway, Codex CLI, Node/npm, Python/pip, kubectl, helm, bun, ripgrep, bubblewrap, npm/pip mirrors for `zh_CN` |
-| `frameworks/sandbox/fastgpt` | `v1` checks plus code-server binary and s6 service registration |
+| `frameworks/sandbox/fastgpt` | `v1` checks plus code-server binary, default `CODE_SERVER_BIND_ADDR=0.0.0.0:1318`, and s6 service registration |

--- a/tests/runtime-conformance/run.sh
+++ b/tests/runtime-conformance/run.sh
@@ -553,6 +553,9 @@ check_sandbox_runtime() {
     [ "${CODE_SERVER_BIND_ADDR:-}" = "0.0.0.0:1318" ] || fail "CODE_SERVER_BIND_ADDR default should be 0.0.0.0:1318"
     assert_file /etc/s6-overlay/s6-rc.d/code-server/run
     assert_file /etc/s6-overlay/s6-rc.d/code-server/finish
+    grep -Fq 'CODE_SERVER_PASSWORD=${DEVBOX_JWT_SECRET:-}' /etc/s6-overlay/s6-rc.d/code-server/run || fail "code-server password should come from DEVBOX_JWT_SECRET"
+    grep -Fq 'export PASSWORD="$CODE_SERVER_PASSWORD"' /etc/s6-overlay/s6-rc.d/code-server/run || fail "code-server should export PASSWORD"
+    grep -q -- '--auth password' /etc/s6-overlay/s6-rc.d/code-server/run || fail "code-server should require password auth"
   fi
   require_zh_npm_mirror
   require_zh_pip_mirror

--- a/tests/runtime-conformance/run.sh
+++ b/tests/runtime-conformance/run.sh
@@ -550,6 +550,7 @@ check_sandbox_runtime() {
   assert_file /etc/s6-overlay/s6-rc.d/codex-gateway/run
   if [ "$RUNTIME_PATH" = "frameworks/sandbox/fastgpt" ]; then
     assert_command code-server
+    [ "${CODE_SERVER_BIND_ADDR:-}" = "0.0.0.0:1318" ] || fail "CODE_SERVER_BIND_ADDR default should be 0.0.0.0:1318"
     assert_file /etc/s6-overlay/s6-rc.d/code-server/run
     assert_file /etc/s6-overlay/s6-rc.d/code-server/finish
   fi


### PR DESCRIPTION
## Summary
- change sandbox/fastgpt code-server default bind address to 0.0.0.0:1318
- expose 1318 instead of 8080 for the fastgpt sandbox image
- use DEVBOX_JWT_SECRET as the code-server PASSWORD and start code-server with password auth
- stop s6 restart loops when code-server is enabled without DEVBOX_JWT_SECRET
- add conformance coverage for the port and password-auth wiring

## Tests
- bash -n base-images/frameworks/sandbox/fastgpt/code-server/run
- bash -n base-images/frameworks/sandbox/fastgpt/code-server/finish
- bash -n tests/runtime-conformance/run.sh
- grep -Fq 'CODE_SERVER_PASSWORD=${DEVBOX_JWT_SECRET:-}' base-images/frameworks/sandbox/fastgpt/code-server/run && grep -Fq 'export PASSWORD="$CODE_SERVER_PASSWORD"' base-images/frameworks/sandbox/fastgpt/code-server/run && grep -q -- '--auth password' base-images/frameworks/sandbox/fastgpt/code-server/run
- git diff --check