### PR TITLE
fix: configure zh_CN PHP mirrors

### DIFF
--- a/base-images/languages/php/7.4/build.sh
+++ b/base-images/languages/php/7.4/build.sh
@@ -4,6 +4,35 @@ set -euo pipefail
 L10N=${L10N:-en_US}
 DEFAULT_DEVBOX_USER=${DEFAULT_DEVBOX_USER:-devbox}
 
+php_apt_source_url() {
+    if [ "$L10N" = "zh_CN" ]; then
+        printf '%s\n' "https://mirrors.ustc.edu.cn/sury/php"
+        return
+    fi
+
+    printf '%s\n' "https://packages.sury.org/php"
+}
+
+configure_php_apt_source() {
+    local source_url
+    source_url="$(php_apt_source_url)"
+
+    wget -O /etc/apt/trusted.gpg.d/php.gpg "${source_url}/apt.gpg"
+    printf 'deb %s/ %s main\n' "$source_url" "$(lsb_release -sc)" >/etc/apt/sources.list.d/php.list
+}
+
+install_composer() {
+    if [ "$L10N" = "zh_CN" ]; then
+        curl -fsSL https://mirrors.aliyun.com/composer/composer.phar -o /usr/local/bin/composer
+        chmod 0755 /usr/local/bin/composer
+        return
+    fi
+
+    curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php
+    php7.4 /tmp/composer-setup.php -- --install-dir=/usr/local/bin --filename=composer
+    rm -f /tmp/composer-setup.php
+}
+
 configure_composer_mirror() {
     local user_home="$1"
     local owner="${2:-}"
@@ -20,8 +49,7 @@ configure_composer_mirror() {
 # Note: wget, curl, and ca-certificates are already installed in the Debian base image layer via install-base-pkg-deb.sh
 apt-get update && \
     apt-get install -y apt-transport-https lsb-release && \
-    wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
-    echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/php.list && \
+    configure_php_apt_source && \
     apt-get update && \
     apt-get install -y \
         php7.4 \
@@ -36,9 +64,7 @@ apt-get update && \
         unzip && \
     update-alternatives --install /usr/bin/php php /usr/bin/php7.4 74 || true && \
     update-alternatives --set php /usr/bin/php7.4 || true && \
-    curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php && \
-    php7.4 /tmp/composer-setup.php -- --install-dir=/usr/local/bin --filename=composer && \
-    rm -f /tmp/composer-setup.php && \
+    install_composer && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/base-images/languages/php/8.2/build.sh
+++ b/base-images/languages/php/8.2/build.sh
@@ -4,6 +4,33 @@ set -euo pipefail
 L10N=${L10N:-en_US}
 DEFAULT_DEVBOX_USER=${DEFAULT_DEVBOX_USER:-devbox}
 
+php_apt_source_url() {
+    if [ "$L10N" = "zh_CN" ]; then
+        printf '%s\n' "https://mirrors.ustc.edu.cn/sury/php"
+        return
+    fi
+
+    printf '%s\n' "https://packages.sury.org/php"
+}
+
+configure_php_apt_source() {
+    local source_url
+    source_url="$(php_apt_source_url)"
+
+    wget -O /etc/apt/trusted.gpg.d/php.gpg "${source_url}/apt.gpg"
+    printf 'deb %s/ %s main\n' "$source_url" "$(lsb_release -sc)" >/etc/apt/sources.list.d/php.list
+}
+
+install_composer() {
+    if [ "$L10N" = "zh_CN" ]; then
+        curl -fsSL https://mirrors.aliyun.com/composer/composer.phar -o /usr/local/bin/composer
+        chmod 0755 /usr/local/bin/composer
+        return
+    fi
+
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+}
+
 configure_composer_mirror() {
     local user_home="$1"
     local owner="${2:-}"
@@ -20,8 +47,7 @@ configure_composer_mirror() {
 # Note: wget, curl, and ca-certificates are already installed in the Debian base image layer via install-base-pkg-deb.sh
 apt-get update && \
     apt-get install -y apt-transport-https lsb-release && \
-    wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
-    echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/php.list && \
+    configure_php_apt_source && \
     apt-get update && \
     apt-get install -y \
         php8.2 \
@@ -37,7 +63,7 @@ apt-get update && \
         unzip && \
     update-alternatives --install /usr/bin/php php /usr/bin/php8.2 100 && \
     update-alternatives --set php /usr/bin/php8.2 && \
-    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    install_composer && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/tests/runtime-conformance/README.md
+++ b/tests/runtime-conformance/README.md
@@ -44,8 +44,8 @@ Runtime-specific checks:
 | `languages/node.js/18` | Node 18, npm/yarn/pnpm, npm mirror for `zh_CN`, root/devbox entrypoint order |
 | `languages/node.js/20` | Node 20, npm/yarn/pnpm, npm mirror for `zh_CN`, root/devbox entrypoint order |
 | `languages/node.js/22` | Node 22, npm/yarn/pnpm, npm mirror for `zh_CN`, root/devbox entrypoint order |
-| `languages/php/7.4` | PHP 7.4, Composer, PHP Redis/MongoDB extensions, Composer mirror for `zh_CN`, root/devbox entrypoint order |
-| `languages/php/8.2` | PHP 8.2, Composer, PHP Redis/MongoDB extensions, Composer mirror for `zh_CN`, root/devbox entrypoint order |
+| `languages/php/7.4` | PHP 7.4, Composer, PHP Redis/MongoDB extensions, PHP APT and Composer mirrors for `zh_CN`, root/devbox entrypoint order |
+| `languages/php/8.2` | PHP 8.2, Composer, PHP Redis/MongoDB extensions, PHP APT and Composer mirrors for `zh_CN`, root/devbox entrypoint order |
 | `languages/python/3.10` | Python 3.10, pip, pip mirror for `zh_CN`, root/devbox entrypoint order |
 | `languages/python/3.11` | Python 3.11, pip, pip mirror for `zh_CN`, root/devbox entrypoint order |
 | `languages/python/3.12` | Python 3.12, pip, pip mirror for `zh_CN`, root/devbox entrypoint order |

--- a/tests/runtime-conformance/run.sh
+++ b/tests/runtime-conformance/run.sh
@@ -374,6 +374,13 @@ require_zh_composer_mirror() {
   as_devbox "composer config -g --list | grep 'mirrors.aliyun.com/composer' >/dev/null" || fail "devbox Composer mirror is not Aliyun"
 }
 
+require_zh_php_apt_mirror() {
+  [ "$L10N" = "zh_CN" ] || return 0
+  log "check zh_CN PHP APT mirror"
+  assert_file /etc/apt/sources.list.d/php.list
+  grep -q 'mirrors.ustc.edu.cn/sury/php' /etc/apt/sources.list.d/php.list || fail "PHP APT source is not USTC"
+}
+
 require_zh_cargo_mirror() {
   [ "$L10N" = "zh_CN" ] || return 0
   log "check zh_CN Cargo mirror"
@@ -446,6 +453,7 @@ check_php_runtime() {
   assert_file "$PROJECT_DIR/hello_world.php"
   php -m | grep -i '^redis$' >/dev/null || fail "PHP redis extension not loaded"
   php -m | grep -i '^mongodb$' >/dev/null || fail "PHP mongodb extension not loaded"
+  require_zh_php_apt_mirror
   require_zh_composer_mirror
 }
 


### PR DESCRIPTION
## Summary
- use the USTC Sury PHP APT mirror for zh_CN PHP 7.4 and 8.2 images
- download Composer from the Aliyun Composer mirror for zh_CN builds
- add conformance coverage for the zh_CN PHP APT mirror

## Tests
- bash -n base-images/languages/php/7.4/build.sh base-images/languages/php/8.2/build.sh tests/runtime-conformance/run.sh
- git diff --check
- verified USTC Sury key and amd64/arm64 package indexes include PHP 7.4/8.2 redis/mongodb packages
