### PR TITLE
feat: install common Debian utilities

### DIFF
--- a/tests/runtime-smoke/operating-systems/debian/12.6/smoke.sh
+++ b/tests/runtime-smoke/operating-systems/debian/12.6/smoke.sh
@@ -55,15 +55,12 @@ if [ ! -f "$project_dir/entrypoint.sh" ]; then
   exit 1
 fi
 
-if ! command -v busybox >/dev/null 2>&1; then
-  echo "busybox not found" >&2
-  exit 1
-fi
-
-if ! command -v unzip >/dev/null 2>&1; then
-  echo "unzip not found" >&2
-  exit 1
-fi
+for cmd in busybox file ip jq less lsof ping ps rsync unzip zip; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd not found" >&2
+    exit 1
+  fi
+done
 
 
 # entrypoint smoke

--- a/tests/runtime-smoke/operating-systems/ubuntu-cuda/12.4.1/smoke.sh
+++ b/tests/runtime-smoke/operating-systems/ubuntu-cuda/12.4.1/smoke.sh
@@ -55,15 +55,12 @@ if [ ! -f "$project_dir/entrypoint.sh" ]; then
   exit 1
 fi
 
-if ! command -v busybox >/dev/null 2>&1; then
-  echo "busybox not found" >&2
-  exit 1
-fi
-
-if ! command -v unzip >/dev/null 2>&1; then
-  echo "unzip not found" >&2
-  exit 1
-fi
+for cmd in busybox file ip jq less lsof ping ps rsync unzip zip; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd not found" >&2
+    exit 1
+  fi
+done
 
 
 # entrypoint smoke

--- a/tests/runtime-smoke/operating-systems/ubuntu/22.04/smoke.sh
+++ b/tests/runtime-smoke/operating-systems/ubuntu/22.04/smoke.sh
@@ -55,15 +55,12 @@ if [ ! -f "$project_dir/entrypoint.sh" ]; then
   exit 1
 fi
 
-if ! command -v busybox >/dev/null 2>&1; then
-  echo "busybox not found" >&2
-  exit 1
-fi
-
-if ! command -v unzip >/dev/null 2>&1; then
-  echo "unzip not found" >&2
-  exit 1
-fi
+for cmd in busybox file ip jq less lsof ping ps rsync unzip zip; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd not found" >&2
+    exit 1
+  fi
+done
 
 
 # entrypoint smoke

--- a/tooling/scripts/install-base-pkg-deb.sh
+++ b/tooling/scripts/install-base-pkg-deb.sh
@@ -7,9 +7,13 @@ apt-get update && \
     curl \
     sudo \
     vim \
+    less \
+    file \
+    jq \
     openssl \
     git \
     xz-utils \
+    zip \
     unzip \
     openssh-client \
     anacron \
@@ -17,7 +21,12 @@ apt-get update && \
     openssh-server \
     locales \
     ca-certificates \
-    busybox
+    busybox \
+    procps \
+    iproute2 \
+    iputils-ping \
+    lsof \
+    rsync
 
 DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
 


### PR DESCRIPTION
## Summary
- install common Debian/Ubuntu utilities in the shared base package script: zip, less, file, jq, procps, iproute2, iputils-ping, lsof, rsync
- extend Debian, Ubuntu, and Ubuntu CUDA smoke tests to verify the corresponding commands are available

## Tests
- bash -n tooling/scripts/install-base-pkg-deb.sh tests/runtime-smoke/operating-systems/debian/12.6/smoke.sh tests/runtime-smoke/operating-systems/ubuntu/22.04/smoke.sh tests/runtime-smoke/operating-systems/ubuntu-cuda/12.4.1/smoke.sh
- git diff --check