### PR TITLE
fix: write keyed Composer packagist mirror

### DIFF
--- a/base-images/languages/php/7.4/build.sh
+++ b/base-images/languages/php/7.4/build.sh
@@ -36,9 +36,21 @@ install_composer() {
 configure_composer_mirror() {
     local user_home="$1"
     local owner="${2:-}"
+    local composer_config_dir="$user_home/.config/composer"
+    local composer_config_file="$composer_config_dir/config.json"
 
-    mkdir -p "$user_home"
-    HOME="$user_home" composer config -g repo.packagist composer https://mirrors.aliyun.com/composer/
+    mkdir -p "$composer_config_dir"
+    cat >"$composer_config_file" <<'EOF'
+{
+    "repositories": {
+        "packagist": {
+            "type": "composer",
+            "url": "https://mirrors.aliyun.com/composer/"
+        }
+    }
+}
+EOF
+    chmod 0600 "$composer_config_file"
 
     if [ -n "$owner" ]; then
         chown -R "$owner:$owner" "$user_home/.config" "$user_home/.composer" 2>/dev/null || true

--- a/base-images/languages/php/8.2/build.sh
+++ b/base-images/languages/php/8.2/build.sh
@@ -34,9 +34,21 @@ install_composer() {
 configure_composer_mirror() {
     local user_home="$1"
     local owner="${2:-}"
+    local composer_config_dir="$user_home/.config/composer"
+    local composer_config_file="$composer_config_dir/config.json"
 
-    mkdir -p "$user_home"
-    HOME="$user_home" composer config -g repo.packagist composer https://mirrors.aliyun.com/composer/
+    mkdir -p "$composer_config_dir"
+    cat >"$composer_config_file" <<'EOF'
+{
+    "repositories": {
+        "packagist": {
+            "type": "composer",
+            "url": "https://mirrors.aliyun.com/composer/"
+        }
+    }
+}
+EOF
+    chmod 0600 "$composer_config_file"
 
     if [ -n "$owner" ]; then
         chown -R "$owner:$owner" "$user_home/.config" "$user_home/.composer" 2>/dev/null || true

--- a/tests/runtime-conformance/run.sh
+++ b/tests/runtime-conformance/run.sh
@@ -370,8 +370,8 @@ require_zh_composer_mirror() {
   [ "$L10N" = "zh_CN" ] || return 0
   log "check zh_CN Composer mirror"
   assert_command composer
-  HOME=/root composer config -g --list | grep 'mirrors.aliyun.com/composer' >/dev/null || fail "root Composer mirror is not Aliyun"
-  as_devbox "composer config -g --list | grep 'mirrors.aliyun.com/composer' >/dev/null" || fail "devbox Composer mirror is not Aliyun"
+  HOME=/root composer config -g repo.packagist | grep 'mirrors.aliyun.com/composer' >/dev/null || fail "root Composer packagist repo is not Aliyun"
+  as_devbox "composer config -g repo.packagist | grep 'mirrors.aliyun.com/composer' >/dev/null" || fail "devbox Composer packagist repo is not Aliyun"
 }
 
 require_zh_php_apt_mirror() {


### PR DESCRIPTION
## Summary
- write Composer Packagist mirror as a keyed global repository for PHP zh_CN images
- make `composer config -g repo.packagist` return the Aliyun mirror instead of failing with no packagist repository
- update conformance to check the exact `repo.packagist` query for root and devbox

## Tests
- bash -n base-images/languages/php/7.4/build.sh base-images/languages/php/8.2/build.sh tests/runtime-conformance/run.sh
- git diff --check labring/main...HEAD

## Context
Validated in the remote cluster that the previous Composer config was written as an indexed repository array (`repositories.0`) and `composer config -g repo.packagist` failed even though `--list` contained the Aliyun URL.
