### PR TITLE
Fix non-root SSH login on OS runtimes

### DIFF
--- a/tests/runtime-smoke/operating-systems/anolis/23.4/smoke.sh
+++ b/tests/runtime-smoke/operating-systems/anolis/23.4/smoke.sh
@@ -69,6 +69,13 @@ if [ ! -x /usr/sbin/sshd ]; then
   exit 1
 fi
 
+for nologin_file in /run/nologin /etc/nologin; do
+  if [ -e "$nologin_file" ]; then
+    echo "$nologin_file blocks non-root SSH logins" >&2
+    exit 1
+  fi
+done
+
 if ! /usr/sbin/sshd -T | grep -qx 'allowtcpforwarding yes'; then
   echo "sshd AllowTcpForwarding is not enabled" >&2
   exit 1

--- a/tests/runtime-smoke/operating-systems/kylin/v10-sp3/smoke.sh
+++ b/tests/runtime-smoke/operating-systems/kylin/v10-sp3/smoke.sh
@@ -69,6 +69,13 @@ if [ ! -x /usr/sbin/sshd ]; then
   exit 1
 fi
 
+for nologin_file in /run/nologin /etc/nologin; do
+  if [ -e "$nologin_file" ]; then
+    echo "$nologin_file blocks non-root SSH logins" >&2
+    exit 1
+  fi
+done
+
 if ! /usr/sbin/sshd -T | grep -qx 'allowtcpforwarding yes'; then
   echo "sshd AllowTcpForwarding is not enabled" >&2
   exit 1

--- a/tooling/scripts/svc/configure-sshd.sh
+++ b/tooling/scripts/svc/configure-sshd.sh
@@ -43,6 +43,7 @@ exec 2>&1
 
 mkdir -p /run/sshd
 chmod 755 /run/sshd
+rm -f /run/nologin /etc/nologin
 
 if ! ls /etc/ssh/ssh_host_*_key >/dev/null 2>&1; then
     if ! command -v ssh-keygen >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- remove stale `/run/nologin` and `/etc/nologin` before starting sshd
- add Kylin and Anolis smoke checks to catch nologin files that block devbox SSH login

## Why
Anolis images can contain `/run/nologin`, and `pam_nologin` rejects non-root SSH users with `System is booting up`. The runtime should clear these container-stale markers before starting sshd.

## Validation
- cherry-picked cleanly from the local fix branch onto latest `labring/main`
- no conflicts handled manually per request