### PR TITLE
fix: repair fastgpt workspace ownership

### DIFF
--- a/base-images/frameworks/sandbox/fastgpt/code-server/run
+++ b/base-images/frameworks/sandbox/fastgpt/code-server/run
@@ -33,7 +33,7 @@ export LOGNAME="$DEFAULT_DEVBOX_USER"
 export PASSWORD="$CODE_SERVER_PASSWORD"
 
 mkdir -p "$WORKSPACE_DIR"
-chown "$DEFAULT_DEVBOX_USER:$DEFAULT_DEVBOX_USER" "$WORKSPACE_DIR" || true
+chown -R "$DEFAULT_DEVBOX_USER:$DEFAULT_DEVBOX_USER" "$WORKSPACE_DIR" || true
 
 if ! command -v code-server >/dev/null 2>&1; then
     echo "code-server binary not found in PATH" >&2

--- a/base-images/frameworks/sandbox/fastgpt/codex-gateway/run
+++ b/base-images/frameworks/sandbox/fastgpt/codex-gateway/run
@@ -66,7 +66,7 @@ if [ -n "$GATEWAY_OPENAI_BASE_URL" ]; then
 fi
 
 mkdir -p "$GATEWAY_CODEX_HOME" "$GATEWAY_CWD"
-chown "$DEFAULT_DEVBOX_USER:$DEFAULT_DEVBOX_USER" "$GATEWAY_CODEX_HOME" "$GATEWAY_CWD" || true
+chown -R "$DEFAULT_DEVBOX_USER:$DEFAULT_DEVBOX_USER" "$GATEWAY_CODEX_HOME" "$GATEWAY_CWD" || true
 
 if [ ! -x /usr/local/bin/codex-gateway ]; then
     echo "codex-gateway binary not found at /usr/local/bin/codex-gateway" >&2

--- a/base-images/frameworks/sandbox/fastgpt/settings.json
+++ b/base-images/frameworks/sandbox/fastgpt/settings.json
@@ -28,5 +28,7 @@
     "window.commandCenter": false,
     "workbench.editor.editorActionsLocation": "hidden",
     "workbench.layoutControl.enabled": false,
-    "workbench.secondarySideBar.defaultVisibility": "hidden"
+    "workbench.secondarySideBar.defaultVisibility": "hidden",
+    "files.autoSave": "afterDelay",
+    "files.autoSaveDelay": 50
 }


### PR DESCRIPTION
## Summary
- recursively repair fastgpt workspace ownership before code-server starts
- recursively repair codex home and workspace ownership before codex-gateway starts
- enable fast auto-save in the fastgpt code-server settings
- use `python3.14 -m pip` for zh_CN pip mirror config so the build does not depend on a `pip3.14` wrapper

## Tests
- bash -n base-images/frameworks/sandbox/fastgpt/build.sh
- bash -n base-images/frameworks/sandbox/fastgpt/code-server/run
- bash -n base-images/frameworks/sandbox/fastgpt/codex-gateway/run
- jq empty base-images/frameworks/sandbox/fastgpt/settings.json
- git diff --check