### PR TITLE
fix: use python module pip in fastgpt build

### DIFF
--- a/base-images/frameworks/sandbox/fastgpt/build.sh
+++ b/base-images/frameworks/sandbox/fastgpt/build.sh
@@ -71,8 +71,8 @@ wget -O "/tmp/helm-${HELM_VERSION}-linux-${KUBECTL_ARCH}.tar.gz" \
 
 if [ "$L10N" = "zh_CN" ]; then
     npm config set registry https://registry.npmmirror.com
-    HOME=/root pip3.14 config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
-    HOME="$DEVBOX_HOME" pip3.14 config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
+    HOME=/root python3.14 -m pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
+    HOME="$DEVBOX_HOME" python3.14 -m pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
     chown -R "$DEFAULT_DEVBOX_USER:$DEFAULT_DEVBOX_USER" "$DEVBOX_HOME/.config" 2>/dev/null || true
 fi
 


### PR DESCRIPTION
## Summary
- replace `pip3.14 config` calls with `python3.14 -m pip config` in the fastgpt build
- avoid depending on a `pip3.14` executable wrapper during zh_CN image builds

## Tests
- bash -n base-images/frameworks/sandbox/fastgpt/build.sh
- git diff --check