### PR TITLE
fix: run fastgpt code-server as root

### DIFF
--- a/base-images/frameworks/sandbox/fastgpt/Dockerfile
+++ b/base-images/frameworks/sandbox/fastgpt/Dockerfile
@@ -35,6 +35,7 @@ COPY --from=codex-gateway /usr/local/bin/codex-gateway /usr/local/bin/codex-gate
 
 # Add build assets and execute them.
 COPY --chown=devbox:devbox settings.json /home/devbox/.local/share/code-server/User/settings.json
+COPY settings.json /root/.local/share/code-server/User/settings.json
 COPY codex-gateway /tmp/codex-gateway-service
 COPY code-server /tmp/code-server-service
 COPY build.sh /build.sh

--- a/base-images/frameworks/sandbox/fastgpt/code-server/run
+++ b/base-images/frameworks/sandbox/fastgpt/code-server/run
@@ -42,7 +42,7 @@ fi
 
 cd "$WORKSPACE_DIR"
 exec 2>&1
-exec s6-setuidgid "$DEFAULT_DEVBOX_USER" code-server \
+exec env HOME=/root USER=root LOGNAME=root code-server \
        --disable-telemetry \
        --disable-update-check \
        --disable-workspace-trust \


### PR DESCRIPTION
## Summary
- run the fastgpt code-server service as root instead of dropping to the devbox user
- install the shared code-server settings under root so the same defaults apply when HOME is /root

## Tests
- bash -n base-images/frameworks/sandbox/fastgpt/code-server/run
- git diff --check