### PR TITLE
sandbox/v1: add Railpack CLI

### DIFF
--- a/base-images/frameworks/sandbox/v1/build.sh
+++ b/base-images/frameworks/sandbox/v1/build.sh
@@ -6,6 +6,7 @@ PYTHON_VERSION=${PYTHON_VERSION:-3.14.0}
 KUBECTL_VERSION=${KUBECTL_VERSION:-v1.33.0}
 HELM_VERSION=${HELM_VERSION:-v3.20.2}
 BUILDKIT_VERSION=${BUILDKIT_VERSION:-v0.30.0}
+RAILPACK_VERSION=${RAILPACK_VERSION:-0.27.0}
 DEFAULT_DEVBOX_USER=${DEFAULT_DEVBOX_USER:-devbox}
 CODEX_GATEWAY_ROOT=${CODEX_GATEWAY_ROOT:-/opt/codex-gateway}
 CODEX_GATEWAY_CODEX_HOME=${CODEX_GATEWAY_CODEX_HOME:-/codex-home}
@@ -23,10 +24,12 @@ case "$ARCH" in
     amd64)
         KUBECTL_ARCH=amd64
         BUILDKIT_ARCH=amd64
+        RAILPACK_ARCH=x86_64
         ;;
     arm64)
         KUBECTL_ARCH=arm64
         BUILDKIT_ARCH=arm64
+        RAILPACK_ARCH=arm64
         ;;
     *)
         echo "Unsupported architecture for kubectl/buildkit: $ARCH" >&2
@@ -74,6 +77,12 @@ wget -O "/tmp/buildkit-${BUILDKIT_VERSION}.linux-${BUILDKIT_ARCH}.tar.gz" \
     install -m 0755 /tmp/bin/buildctl /usr/local/bin/buildctl && \
     rm -rf "/tmp/buildkit-${BUILDKIT_VERSION}.linux-${BUILDKIT_ARCH}.tar.gz" /tmp/bin
 
+wget -O "/tmp/railpack-v${RAILPACK_VERSION}-${RAILPACK_ARCH}-unknown-linux-musl.tar.gz" \
+    "https://github.com/railwayapp/railpack/releases/download/v${RAILPACK_VERSION}/railpack-v${RAILPACK_VERSION}-${RAILPACK_ARCH}-unknown-linux-musl.tar.gz" && \
+    tar -C /usr/local/bin -xzf "/tmp/railpack-v${RAILPACK_VERSION}-${RAILPACK_ARCH}-unknown-linux-musl.tar.gz" && \
+    chmod 0755 /usr/local/bin/railpack && \
+    rm -f "/tmp/railpack-v${RAILPACK_VERSION}-${RAILPACK_ARCH}-unknown-linux-musl.tar.gz"
+
 if [ "$L10N" = "zh_CN" ]; then
     npm config set registry https://registry.npmmirror.com
     HOME=/root pip3.14 config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
@@ -86,6 +95,7 @@ bun --version
 kubectl version --client
 helm version --short
 buildctl --version
+railpack --version
 python3.14 --version
 rg --version
 

--- a/tests/runtime-conformance/README.md
+++ b/tests/runtime-conformance/README.md
@@ -55,5 +55,5 @@ Runtime-specific checks:
 | `frameworks/nest.js/v11` | Node 20, Nest CLI, npm mirror for `zh_CN`, build output, root/devbox entrypoint order |
 | `frameworks/nginx/1.22.1` | Nginx 1.22.1, config test, `/tmp/nginx-devbox` runtime paths, no distro default include pollution, root/devbox entrypoint order |
 | `frameworks/openclaw/latest` | Node 22, OpenClaw, Clawhub, Bun, npm mirror for `zh_CN`, safe `.env.example`, root/devbox entrypoint order |
-| `frameworks/sandbox/v1` | workspace ownership, codex-gateway, Codex CLI, Node/npm, Python/pip, kubectl, helm, bun, ripgrep, bubblewrap, npm/pip mirrors for `zh_CN` |
+| `frameworks/sandbox/v1` | workspace ownership, codex-gateway, Codex CLI, Node/npm, Python/pip, kubectl, helm, bun, ripgrep, bubblewrap, Railpack CLI, npm/pip mirrors for `zh_CN` |
 | `frameworks/sandbox/fastgpt` | `v1` checks plus fastgpt-ide-agent binary and s6 service registration |

--- a/tests/runtime-conformance/run.sh
+++ b/tests/runtime-conformance/run.sh
@@ -555,6 +555,9 @@ check_sandbox_runtime() {
   assert_command bun
   assert_command rg
   assert_command bwrap
+  assert_command railpack
+  railpack --version >/dev/null
+  railpack schema >/dev/null
   assert_file /etc/s6-overlay/s6-rc.d/codex-gateway/run
   if [ "$RUNTIME_PATH" = "frameworks/sandbox/fastgpt" ]; then
     assert_executable /usr/local/bin/fastgpt-ide-agent

--- a/tests/runtime-smoke/frameworks/sandbox/v1/smoke.sh
+++ b/tests/runtime-smoke/frameworks/sandbox/v1/smoke.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -eu
+
+workspace_dir=/home/devbox/workspace
+
+if [ ! -d "$workspace_dir" ]; then
+  echo "Missing workspace dir: $workspace_dir" >&2
+  exit 1
+fi
+
+# load profile env (best effort)
+set +u
+[ -f /etc/profile ] && . /etc/profile || true
+if [ -d /etc/profile.d ]; then
+  for f in /etc/profile.d/*.sh; do
+    [ -r "$f" ] && . "$f" || true
+  done
+fi
+[ -f /home/devbox/.bashrc ] && . /home/devbox/.bashrc || true
+set -u
+
+if [ "${SMOKE_DEBUG:-}" = "1" ]; then
+  echo "SMOKE_DEBUG=1"
+  echo "user=$(id -un) uid=$(id -u) gid=$(id -g)"
+  echo "HOME=$HOME"
+  echo "SHELL=${SHELL:-}"
+  echo "PATH=$PATH"
+  for cmd in codex node npm python3 pip3 kubectl helm buildctl bun rg bwrap railpack; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+      echo "cmd:$cmd=$(command -v "$cmd")"
+    else
+      echo "cmd:$cmd=missing"
+    fi
+  done
+fi
+
+cd "$workspace_dir"
+
+for cmd in codex node npm python3 pip3 kubectl helm buildctl bun rg bwrap railpack; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd not found" >&2
+    exit 1
+  fi
+done
+
+if [ ! -x /usr/local/bin/codex-gateway ]; then
+  echo "codex-gateway binary not found" >&2
+  exit 1
+fi
+
+railpack --version >/dev/null
+railpack schema >/dev/null
+
+echo "ok"


### PR DESCRIPTION
## Summary
- install Railpack CLI v0.27.0 in the sandbox/v1 base image for amd64 and arm64
- verify Railpack availability during image build with `railpack --version`
- add sandbox/v1 smoke and conformance checks for `railpack --version` and `railpack schema`

## Validation
- `bash -n base-images/frameworks/sandbox/v1/build.sh tests/runtime-conformance/run.sh tests/runtime-smoke/frameworks/sandbox/v1/smoke.sh`
- `git diff --check`

Note: I also fetched the official Railpack install script and CLI markdown reference. A direct local GitHub release tarball download for the binary timed out from this environment, so full image-build validation is left to CI.