### PR TITLE
[codex] add fedora 44 runtime

### DIFF
--- a/base-images/operating-systems/fedora/44/Dockerfile
+++ b/base-images/operating-systems/fedora/44/Dockerfile
@@ -1,0 +1,49 @@
+# These ARGs can be overridden at build time to customize the image
+ARG REGISTRY=ghcr.io
+ARG TOOLING_REPO=labring-actions/devbox-tooling
+ARG L10N=en_US
+ARG TARGETARCH
+ARG ARCH=${TARGETARCH:-amd64}
+ARG DEFAULT_DEVBOX_USER=devbox
+ARG FEDORA_IMAGE=fedora:44
+# These ARGs are not recommended to be overridden at build time.
+# Instead, update the Dockerfile directly for consistent builds,
+# and release new versions as needed.
+ARG BASE_TOOLS_VERSION=v0.0.1-alpha.1
+
+FROM ${REGISTRY}/${TOOLING_REPO}/tooling:${BASE_TOOLS_VERSION} AS tooling
+FROM ${FEDORA_IMAGE}
+ARG L10N
+ARG TARGETARCH
+ARG ARCH=${TARGETARCH:-amd64}
+ARG DEFAULT_DEVBOX_USER
+LABEL org.opencontainers.image.authors="The Devbox Authors"
+# Define some environment variables
+## BASE_TOOLS_DIR: Directory where base tools are installed
+ENV BASE_TOOLS_DIR=/opt/base-tools
+## L10N: Internationalization setting
+ENV L10N=${L10N}
+## ARCH: System architecture (from build-arg)
+ENV ARCH=${ARCH}
+## DEFAULT_DEVBOX_USER: Default user for the devbox environment
+ENV DEFAULT_DEVBOX_USER=${DEFAULT_DEVBOX_USER}
+## PROJECT_DIR: Default devbox project directory inside the container
+ENV PROJECT_DIR=/home/devbox/project
+## S6_STAGE2_HOOK: Hook script executed BEFORE s6-rc compilation
+## This allows us to dynamically disable services based on DEVBOX_ENV
+ENV S6_STAGE2_HOOK=/etc/s6-overlay-hook/pre-rc-init.d/pre-rc-init.sh
+## S6_KILL_GRACETIME: Time to wait before forcefully killing all processes during shutdown
+ENV S6_KILL_GRACETIME=500
+
+# Copy tooling assets from the tooling stage
+COPY --from=tooling ${BASE_TOOLS_DIR} ${BASE_TOOLS_DIR}
+# Add build script and execute it
+COPY build.sh /build.sh
+RUN chmod +x /build.sh && \
+    /build.sh && \
+    rm -f /build.sh && \
+    rm -rf ${BASE_TOOLS_DIR}
+## Locale: generated during build, but also export at runtime so non-login processes use UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENTRYPOINT [ "/init" ]

--- a/base-images/operating-systems/fedora/44/build.sh
+++ b/base-images/operating-systems/fedora/44/build.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Current BASE_TOOLS_DIR: $BASE_TOOLS_DIR"
+echo "Current L10N: $L10N"
+echo "Current ARCH: $ARCH"
+echo "Current DEFAULT_DEVBOX_USER: $DEFAULT_DEVBOX_USER"
+
+chmod +x "$BASE_TOOLS_DIR/scripts/"*.sh
+
+# Install base packages for Fedora/RPM family
+"$BASE_TOOLS_DIR/scripts/install-base-pkg-rpm.sh"
+
+# Install cron, s6, and the SDK server from the shared tooling scripts
+"$BASE_TOOLS_DIR/scripts/install-crond.sh"
+"$BASE_TOOLS_DIR/scripts/install-s6.sh"
+"$BASE_TOOLS_DIR/scripts/install-sdk-server.sh"
+
+# Configure svc
+"$BASE_TOOLS_DIR/scripts/configure-svc.sh"
+
+# Configure other utilities
+"$BASE_TOOLS_DIR/scripts/configure-logrotate.sh"
+"$BASE_TOOLS_DIR/scripts/configure-login.sh"
+
+# Configure localization (L10N)
+"$BASE_TOOLS_DIR/scripts/configure-l10n.sh"
+
+# Configure user devbox
+"$BASE_TOOLS_DIR/scripts/configure-user.sh" "$DEFAULT_DEVBOX_USER"
+
+# Install user-facing runtime docs (single source from the shared tooling bundle)
+if [ -d "$BASE_TOOLS_DIR/docs" ]; then
+    install -d /usr/share/devbox/docs
+    cp "$BASE_TOOLS_DIR"/docs/README.s6-user-guide*.md /usr/share/devbox/docs/
+    chmod 644 /usr/share/devbox/docs/README.s6-user-guide*.md
+else
+    echo "No docs directory found in $BASE_TOOLS_DIR; skipping s6 user-guide install"
+fi
+
+# Cleanup
+"$BASE_TOOLS_DIR/scripts/cleanup.sh"

--- a/runtime-images/operating-systems/fedora/44/Dockerfile
+++ b/runtime-images/operating-systems/fedora/44/Dockerfile
@@ -1,0 +1,25 @@
+# These ARGs can be overridden at build time to customize the image
+ARG REPO=labring-actions/devbox-base-images
+ARG REGISTRY=ghcr.io
+ARG L10N=en_US
+ARG L10N_NORMALIZED=en-us
+ARG DEFAULT_DEVBOX_USER=devbox
+
+# These ARGs are not recommended to be overridden at build time.
+# Instead, update the Dockerfile directly for consistent builds,
+# and release new versions as needed.
+ARG OS_IMAGE_VERSION=v0.0.1-alpha.1-${L10N_NORMALIZED}
+
+FROM ${REGISTRY}/${REPO}/fedora-44:${OS_IMAGE_VERSION}
+ARG L10N
+ARG DEFAULT_DEVBOX_USER
+ENV L10N=${L10N}
+ENV PROJECT_TEMPLATE_DIR=/project-template
+COPY ./project-template ${PROJECT_TEMPLATE_DIR}
+COPY ./build.sh /build.sh
+RUN chmod +x /build.sh && \
+    /build.sh && \
+    rm -f /build.sh && \
+    rm -rf ${PROJECT_TEMPLATE_DIR}
+# Set the working directory to the default devbox user's project directory
+WORKDIR /home/${DEFAULT_DEVBOX_USER}/project

--- a/runtime-images/operating-systems/fedora/44/build.sh
+++ b/runtime-images/operating-systems/fedora/44/build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+L10N=${L10N:-en_US}
+DEFAULT_DEVBOX_USER=${DEFAULT_DEVBOX_USER:-devbox}
+PROJECT_TEMPLATE_DIR=${PROJECT_TEMPLATE_DIR:-/project-templates}
+DOCS_DIR=${DOCS_DIR:-/usr/share/devbox/docs}
+
+if ! id -u "$DEFAULT_DEVBOX_USER" &>/dev/null; then
+  echo "User $DEFAULT_DEVBOX_USER does not exist"
+  exit 1
+fi
+
+TARGET_DIR="/home/$DEFAULT_DEVBOX_USER/project"
+mkdir -p "$TARGET_DIR"
+
+if [ -f "$PROJECT_TEMPLATE_DIR/README.$L10N.md" ]; then
+  echo "README $PROJECT_TEMPLATE_DIR/README.$L10N.md exists. Copying to $TARGET_DIR/README.md"
+  cp "$PROJECT_TEMPLATE_DIR/README.$L10N.md" "$TARGET_DIR/README.md"
+else
+  echo "README $PROJECT_TEMPLATE_DIR/README.$L10N.md does not exist. Skipping copy."
+fi
+
+if [ -f "$DOCS_DIR/README.s6-user-guide.$L10N.md" ]; then
+  cp "$DOCS_DIR/README.s6-user-guide.$L10N.md" "$TARGET_DIR/README.s6-user-guide.md"
+elif [ -f "$DOCS_DIR/README.s6-user-guide.en_US.md" ]; then
+  cp "$DOCS_DIR/README.s6-user-guide.en_US.md" "$TARGET_DIR/README.s6-user-guide.md"
+fi
+
+cp "$PROJECT_TEMPLATE_DIR/"*.sh "$TARGET_DIR/"
+chmod 0755 "$TARGET_DIR/"*.sh
+
+# Set ownership to default devbox user
+chown -R "$DEFAULT_DEVBOX_USER:$DEFAULT_DEVBOX_USER" "$TARGET_DIR"

--- a/runtime-images/operating-systems/fedora/44/project-template/README.en_US.md
+++ b/runtime-images/operating-systems/fedora/44/project-template/README.en_US.md
@@ -1,0 +1,46 @@
+# Fedora 44 Runtime Template
+
+This template provides a minimal **operating-system runtime** based on Fedora 44.
+Use it when you need a modern RPM-family Linux base and full control of your language, framework, or application stack.
+
+## Runtime Summary
+
+- OS version: `Fedora 44`
+- Base runtime image: `fedora-44`
+- Entrypoint script: `entrypoint.sh`
+- Default service port: `8080`
+
+## Template Files
+
+- `entrypoint.sh`: creates a static `index.html` and starts a lightweight HTTP server
+
+## Run in DevBox
+
+Run commands from `/home/devbox/project`.
+
+```bash
+bash entrypoint.sh
+```
+
+Behavior:
+- Uses `PORT` environment variable when provided, defaults to `8080`.
+- Serves files from `/home/devbox/project/www`.
+- Prefers `busybox httpd` and falls back to `python3 -m http.server` when that applet is unavailable.
+
+## Verify Service
+
+```bash
+curl http://127.0.0.1:8080
+```
+
+Expected output:
+
+```text
+Hello, World!
+```
+
+## Customization
+
+- Replace `entrypoint.sh` with your own process startup script.
+- Use `dnf` to install application dependencies in this Fedora base.
+- Align container exposed ports with your service port.

--- a/runtime-images/operating-systems/fedora/44/project-template/README.zh_CN.md
+++ b/runtime-images/operating-systems/fedora/44/project-template/README.zh_CN.md
@@ -1,0 +1,46 @@
+# Fedora 44 运行时模板
+
+该模板提供一个基于 Fedora 44 的最小化**操作系统运行时**。
+适用于需要较新的 RPM 系 Linux 基础环境，并在其上自行安装语言、框架或业务依赖的场景。
+
+## 运行时概览
+
+- 系统版本：`Fedora 44`
+- 基础运行时镜像：`fedora-44`
+- 启动脚本：`entrypoint.sh`
+- 默认服务端口：`8080`
+
+## 模板文件
+
+- `entrypoint.sh`：生成静态 `index.html` 并启动轻量 HTTP 服务
+
+## 在 DevBox 中运行
+
+以下命令在 `/home/devbox/project` 目录执行。
+
+```bash
+bash entrypoint.sh
+```
+
+行为说明：
+- 支持通过 `PORT` 环境变量覆盖端口，默认值为 `8080`。
+- 默认从 `/home/devbox/project/www` 目录提供静态内容。
+- 优先使用 `busybox httpd`，不可用时回退到 `python3 -m http.server`。
+
+## 验证服务
+
+```bash
+curl http://127.0.0.1:8080
+```
+
+预期输出：
+
+```text
+Hello, World!
+```
+
+## 自定义建议
+
+- 可将 `entrypoint.sh` 替换为你的进程启动脚本。
+- 使用 `dnf` 在该 Fedora 基础镜像中安装业务依赖。
+- 保持容器暴露端口与服务监听端口一致。

--- a/runtime-images/operating-systems/fedora/44/project-template/entrypoint.sh
+++ b/runtime-images/operating-systems/fedora/44/project-template/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$(id -u)" -eq 0 ] && [ "${DEVBOX_ENTRYPOINT_AS_DEVBOX:-1}" = "1" ] && id devbox >/dev/null 2>&1; then
+    export DEVBOX_ENTRYPOINT_AS_DEVBOX=0
+    SCRIPT_PATH=$(readlink -f "$0")
+    exec runuser -u devbox -- bash "$SCRIPT_PATH" "$@"
+fi
+
+# Serve a simple "Hello, World!" page
+PORT=${PORT:-8080}
+PROJECT_DIR=${PROJECT_DIR:-/home/devbox/project}
+ROOT_DIR="$PROJECT_DIR/www"
+mkdir -p "$ROOT_DIR"
+
+cat >"$ROOT_DIR/index.html" <<'HTML'
+Hello, World!
+HTML
+
+echo "Starting HTTP server on port $PORT (serving $ROOT_DIR)"
+
+if command -v busybox >/dev/null 2>&1 && busybox --list 2>/dev/null | grep -qx httpd; then
+    exec busybox httpd -f -p "$PORT" -h "$ROOT_DIR"
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+    cd "$ROOT_DIR"
+    exec python3 -m http.server "$PORT" --bind 0.0.0.0
+fi
+
+echo "No supported HTTP server found (busybox httpd or python3 http.server)." >&2
+exit 1

--- a/tests/runtime-conformance/run.sh
+++ b/tests/runtime-conformance/run.sh
@@ -599,6 +599,9 @@ check_runtime_specifics() {
     operating-systems/anolis/23.4)
       check_os_runtime anolis
       ;;
+    operating-systems/fedora/44)
+      check_os_runtime fedora
+      ;;
     operating-systems/debian/12.6)
       check_os_runtime debian
       ;;

--- a/tests/runtime-smoke/operating-systems/fedora/44/smoke.sh
+++ b/tests/runtime-smoke/operating-systems/fedora/44/smoke.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+set -eu
+
+project_dir=/home/devbox/project
+
+if [ ! -d "$project_dir" ]; then
+  echo "Missing project dir: $project_dir" >&2
+  exit 1
+fi
+
+# load profile env (best effort)
+set +u
+[ -f /etc/profile ] && . /etc/profile || true
+if [ -d /etc/profile.d ]; then
+  for f in /etc/profile.d/*.sh; do
+    [ -r "$f" ] && . "$f" || true
+  done
+fi
+[ -f /home/devbox/.bashrc ] && . /home/devbox/.bashrc || true
+set -u
+
+if [ "${SMOKE_DEBUG:-}" = "1" ]; then
+  echo "SMOKE_DEBUG=1"
+  echo "user=$(id -un) uid=$(id -u) gid=$(id -g)"
+  echo "HOME=$HOME"
+  echo "SHELL=${SHELL:-}"
+  echo "PATH=$PATH"
+  for cmd in dnf rpm busybox bash sudo curl wget git python3 tar gzip unzip ssh; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+      echo "cmd:$cmd=$(command -v "$cmd")"
+    else
+      echo "cmd:$cmd=missing"
+    fi
+  done
+fi
+
+if ! grep -qi fedora /etc/os-release; then
+  echo "Expected Fedora in /etc/os-release" >&2
+  exit 1
+fi
+
+if ! grep -Eq 'VERSION_ID="?44"?' /etc/os-release; then
+  echo "Expected Fedora 44 in /etc/os-release" >&2
+  exit 1
+fi
+
+if ! id devbox >/dev/null 2>&1; then
+  echo "User devbox not found" >&2
+  exit 1
+fi
+
+if [ ! -f "$project_dir/README.md" ]; then
+  echo "Missing README.md in $project_dir" >&2
+  exit 1
+fi
+
+if [ ! -f "$project_dir/entrypoint.sh" ]; then
+  echo "Missing entrypoint.sh in $project_dir" >&2
+  exit 1
+fi
+
+for cmd in dnf rpm busybox bash sudo curl wget git python3 tar gzip unzip ssh; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd not found" >&2
+    exit 1
+  fi
+done
+
+if [ ! -x /usr/sbin/sshd ]; then
+  echo "sshd not found" >&2
+  exit 1
+fi
+
+sshd_config_dump() {
+  if [ "$(id -u)" -eq 0 ]; then
+    /usr/sbin/sshd -T
+    return
+  fi
+  if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+    sudo /usr/sbin/sshd -T
+    return
+  fi
+  if command -v ssh-keygen >/dev/null 2>&1; then
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+    ssh-keygen -q -t ed25519 -N "" -f "$tmp_dir/ssh_host_ed25519_key"
+    /usr/sbin/sshd -T -h "$tmp_dir/ssh_host_ed25519_key"
+    return
+  fi
+  /usr/sbin/sshd -T
+}
+
+for nologin_file in /run/nologin /etc/nologin; do
+  if [ -e "$nologin_file" ]; then
+    echo "$nologin_file blocks non-root SSH logins" >&2
+    exit 1
+  fi
+done
+
+if ! sshd_config_dump | grep -qx 'allowtcpforwarding yes'; then
+  echo "sshd AllowTcpForwarding is not enabled" >&2
+  exit 1
+fi
+
+glibc_version="$(ldd --version | head -n1 | grep -oE '[0-9]+[.][0-9]+' | tail -n1)"
+if ! awk -v version="$glibc_version" 'BEGIN { split(version, v, "."); exit !((v[1] > 2) || (v[1] == 2 && v[2] >= 28)) }'; then
+  echo "glibc $glibc_version is older than the VS Code Server minimum 2.28" >&2
+  exit 1
+fi
+
+if ! grep -ao 'GLIBCXX_3\.4\.25' /usr/lib64/libstdc++.so.6 >/dev/null 2>&1; then
+  echo "libstdc++ does not provide GLIBCXX_3.4.25 required by VS Code Server" >&2
+  exit 1
+fi
+
+# entrypoint smoke
+entrypoint="$project_dir/entrypoint.sh"
+if [ ! -f "$entrypoint" ]; then
+  echo "Missing entrypoint.sh in $project_dir" >&2
+  exit 1
+fi
+
+if ! command -v bash >/dev/null 2>&1; then
+  echo "bash not found" >&2
+  exit 1
+fi
+
+( cd "$project_dir" && bash "$entrypoint" ) >/tmp/entrypoint.log 2>&1 &
+pid=$!
+sleep 3
+if ! kill -0 "$pid" >/dev/null 2>&1; then
+  echo "entrypoint exited early" >&2
+  echo "---- entrypoint log ----" >&2
+  cat /tmp/entrypoint.log >&2 || true
+  exit 1
+fi
+kill "$pid" >/dev/null 2>&1 || true
+wait "$pid" >/dev/null 2>&1 || true
+
+echo "ok"

--- a/tooling/scripts/install-base-pkg-rpm.sh
+++ b/tooling/scripts/install-base-pkg-rpm.sh
@@ -31,6 +31,7 @@ fi
 
 "$PM" install -y \
     bash \
+    binutils \
     busybox \
     ca-certificates \
     cpio \
@@ -50,6 +51,7 @@ fi
     shadow \
     sudo \
     tar \
+    unzip \
     util-linux \
     vim-enhanced \
     wget \

--- a/tooling/scripts/svc/configure-sshd.sh
+++ b/tooling/scripts/svc/configure-sshd.sh
@@ -32,6 +32,8 @@ set_sshd_config 'PasswordAuthentication no'
 set_sshd_config 'PubKeyAuthentication yes'
 set_sshd_config 'PermitRootLogin prohibit-password'
 set_sshd_config 'PermitEmptyPasswords no'
+chmod 0644 "$SSHD_CONFIG"
+ssh-keygen -A
 mkdir -p /run/sshd && chmod 755 /run/sshd
 
 # sshd service


### PR DESCRIPTION
## Summary

Adds Fedora 44 as a DevBox operating-system runtime.

## Changes

- Add Fedora 44 base image and runtime image definitions.
- Add localized Fedora 44 project templates for `en_US` and `zh_CN`.
- Register Fedora 44 in runtime smoke and conformance tests.
- Add `binutils` and `unzip` to the RPM-family base package installer for VS Code Server prerequisites.
- Ensure sshd config permissions and host keys are initialized during image build.
- Ensure Fedora project template shell scripts are executable after being copied into `/home/devbox/project`.

## Validation

Local/static:

- `git diff --check`
- `bash -n` for Fedora build scripts, smoke script, project entrypoint, conformance runner, and touched tooling scripts
- `python3 .github/scripts/runtime-conformance.py plan --tag fedora44-test --kind operating-systems --name fedora/44 --l10n both --arch amd64`

Native arm64 local validation already passed before PR creation:

- Built `en_US` and `zh_CN` Fedora 44 base/runtime images.
- Smoke passed for both localized runtime images.
- Runtime conformance passed for both localized runtime images.
- Full `/init` startup check passed for `en_US` with s6 and sshd running.

Test environment validation on `root@192.168.10.230`:

- Test host had no Docker/buildkit, so validation used an isolated privileged Docker-in-Docker container via existing `nerdctl`, then removed all temporary test artifacts.
- Built `linux/amd64` Fedora 44 base/runtime images for `en_US` and `zh_CN` with tag `fedora44-test`.
- Basic runtime checks passed for Fedora 44 identity, `devbox` user, project files, `dnf`, `rpm`, `busybox`, `bash`, `sudo`, `curl`, `wget`, `git`, `python3`, and `sshd`.
- Smoke passed for both `en_US` and `zh_CN`.
- Runtime conformance passed for both `en_US` and `zh_CN` on `amd64`.
- Full `/init` startup check passed: container stayed running, s6/s6-supervise processes were present, sshd listener was present, and sshd config included `allowtcpforwarding yes`, `passwordauthentication no`, and `pubkeyauthentication yes`.
- Observed image sizes in test env: `en_US` runtime `188753584` bytes compressed by Docker inspect output path, `zh_CN` runtime `263555554` bytes compressed by Docker inspect output path; Docker image listing showed approx `734MB` and `947MB` unpacked virtual size.

Known limitation:

- Local Apple/OrbStack `linux/amd64` emulation failed while extracting s6 overlay with `Function not implemented`; amd64 was instead validated on the provided amd64 test host and will be covered by GitHub Actions.

## Follow-up Actions

After this PR is open, run GitHub Actions with `tag=fedora44-test`, `target=runtime/os/fedora/44`, `l10n=both`, and `arch=both` to validate the full matrix.
