### PR TITLE
[codex] add OpenJDK 8 runtime template

### DIFF
--- a/base-images/languages/java/openjdk8/Dockerfile
+++ b/base-images/languages/java/openjdk8/Dockerfile
@@ -1,0 +1,24 @@
+# These ARGs can be overridden at build time to customize the image
+ARG REPO=labring-actions/devbox-base-images
+ARG REGISTRY=ghcr.io
+ARG L10N=en_US
+ARG L10N_NORMALIZED=en-us
+
+# These ARGs are not recommended to be overridden at build time.
+# Instead, update the Dockerfile directly for consistent builds,
+# and release new versions as needed.
+ARG OS_IMAGE_VERSION=v0.0.1-alpha.1-${L10N_NORMALIZED}
+
+FROM ${REGISTRY}/${REPO}/debian-12.6:${OS_IMAGE_VERSION}
+ARG L10N
+ARG TARGETARCH
+LABEL org.opencontainers.image.authors="The Devbox Authors"
+ENV L10N=${L10N}
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk
+ENV MAVEN_HOME=/opt/maven
+ENV PATH=${JAVA_HOME}/bin:${MAVEN_HOME}/bin:${PATH}
+# Add build script and execute it
+COPY build.sh /build.sh
+RUN chmod +x /build.sh && \
+    TARGETARCH="${TARGETARCH}" /build.sh && \
+    rm -f /build.sh

--- a/base-images/languages/java/openjdk8/build.sh
+++ b/base-images/languages/java/openjdk8/build.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+L10N=${L10N:-en_US}
+DEFAULT_DEVBOX_USER=${DEFAULT_DEVBOX_USER:-devbox}
+JAVA_HOME=${JAVA_HOME:-/usr/lib/jvm/java-8-openjdk}
+MAVEN_HOME=${MAVEN_HOME:-/opt/maven}
+TEMURIN_VERSION=8u492b09
+TEMURIN_RELEASE=jdk8u492-b09
+MAVEN_VERSION=3.9.16
+MAVEN_SHA512=831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0cafb8338851f90780735568773e0a6cd07bbec107cda0b896b008b861075358b6f6
+
+apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RAW_ARCH="${TARGETARCH:-}"
+if [ -z "$RAW_ARCH" ]; then
+    RAW_ARCH="$(dpkg --print-architecture 2>/dev/null || true)"
+fi
+if [ -z "$RAW_ARCH" ]; then
+    RAW_ARCH="${ARCH:-}"
+fi
+
+case "$RAW_ARCH" in
+    amd64|x86_64)
+        TEMURIN_ARCH=x64
+        TEMURIN_SHA256=da257f161d7f8c6ca5b0e5d9e4090f65ac28c5e398072e68b8ae87988b1d1a2e
+        ;;
+    arm64|aarch64)
+        TEMURIN_ARCH=aarch64
+        TEMURIN_SHA256=3c2253b986909c20f79d6de7a0cb957f89c243df57615897836046e24d2e5257
+        ;;
+    *)
+        echo "Unsupported architecture: $RAW_ARCH" >&2
+        exit 1
+        ;;
+esac
+
+TEMURIN_ARCHIVE="OpenJDK8U-jdk_${TEMURIN_ARCH}_linux_hotspot_${TEMURIN_VERSION}.tar.gz"
+TEMURIN_URL="https://github.com/adoptium/temurin8-binaries/releases/download/${TEMURIN_RELEASE}/${TEMURIN_ARCHIVE}"
+curl -fsSL "$TEMURIN_URL" -o "/tmp/${TEMURIN_ARCHIVE}"
+echo "${TEMURIN_SHA256}  /tmp/${TEMURIN_ARCHIVE}" | sha256sum -c -
+mkdir -p "$JAVA_HOME"
+tar -xzf "/tmp/${TEMURIN_ARCHIVE}" -C "$JAVA_HOME" --strip-components=1
+rm -f "/tmp/${TEMURIN_ARCHIVE}"
+
+MAVEN_ARCHIVE="apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+MAVEN_URL="https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/${MAVEN_ARCHIVE}"
+curl -fsSL "$MAVEN_URL" -o "/tmp/${MAVEN_ARCHIVE}"
+echo "${MAVEN_SHA512}  /tmp/${MAVEN_ARCHIVE}" | sha512sum -c -
+mkdir -p "$MAVEN_HOME"
+tar -xzf "/tmp/${MAVEN_ARCHIVE}" -C "$MAVEN_HOME" --strip-components=1
+rm -f "/tmp/${MAVEN_ARCHIVE}"
+
+cat > /etc/profile.d/java-env.sh <<EOF
+export JAVA_HOME=$JAVA_HOME
+export MAVEN_HOME=$MAVEN_HOME
+export PATH=\$JAVA_HOME/bin:\$MAVEN_HOME/bin:\$PATH
+EOF
+chmod 644 /etc/profile.d/java-env.sh
+
+ROOT_HOME="${HOME:-/root}"
+DEVBOX_USER="$DEFAULT_DEVBOX_USER"
+DEVBOX_HOME="$(getent passwd "$DEVBOX_USER" | cut -d: -f6 || true)"
+if [ -z "$DEVBOX_HOME" ]; then
+    DEVBOX_HOME="/home/${DEVBOX_USER}"
+fi
+
+for shell_rc in "$ROOT_HOME/.bashrc" "$DEVBOX_HOME/.bashrc"; do
+    grep -qxF "export JAVA_HOME=$JAVA_HOME" "$shell_rc" 2>/dev/null || \
+        echo "export JAVA_HOME=$JAVA_HOME" >> "$shell_rc" 2>/dev/null || true
+    grep -qxF "export MAVEN_HOME=$MAVEN_HOME" "$shell_rc" 2>/dev/null || \
+        echo "export MAVEN_HOME=$MAVEN_HOME" >> "$shell_rc" 2>/dev/null || true
+    grep -qxF 'export PATH=$JAVA_HOME/bin:$MAVEN_HOME/bin:$PATH' "$shell_rc" 2>/dev/null || \
+        echo 'export PATH=$JAVA_HOME/bin:$MAVEN_HOME/bin:$PATH' >> "$shell_rc" 2>/dev/null || true
+done
+
+if [ "$L10N" = "zh_CN" ]; then
+    mkdir -p "$DEVBOX_HOME/.m2"
+    cat > "$DEVBOX_HOME/.m2/settings.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>aliyunmaven</id>
+      <mirrorOf>central</mirrorOf>
+      <name>Aliyun Maven</name>
+      <url>https://maven.aliyun.com/repository/public</url>
+    </mirror>
+  </mirrors>
+</settings>
+EOF
+    chown -R "${DEVBOX_USER}:${DEVBOX_USER}" "$DEVBOX_HOME/.m2" || true
+fi
+
+export JAVA_HOME MAVEN_HOME
+export PATH="$JAVA_HOME/bin:$MAVEN_HOME/bin:$PATH"
+java -version
+javac -version
+mvn -version

--- a/runtime-images/languages/java/openjdk8/Dockerfile
+++ b/runtime-images/languages/java/openjdk8/Dockerfile
@@ -1,0 +1,24 @@
+# These ARGs can be overridden at build time to customize the image
+ARG REPO=labring-actions/devbox-base-images
+ARG REGISTRY=ghcr.io
+ARG L10N=en_US
+ARG L10N_NORMALIZED=en-us
+
+# These ARGs are not recommended to be overridden at build time.
+# Instead, update the Dockerfile directly for consistent builds,
+# and release new versions as needed.
+ARG RUNTIME_IMAGE_VERSION=v0.0.1-alpha.1-${L10N_NORMALIZED}
+
+FROM ${REGISTRY}/${REPO}/java-openjdk8:${RUNTIME_IMAGE_VERSION}
+ARG L10N
+LABEL org.opencontainers.image.authors="The Devbox Authors"
+ENV L10N=${L10N}
+ENV PROJECT_TEMPLATE_DIR=/project-template
+COPY ./project-template ${PROJECT_TEMPLATE_DIR}
+COPY ./build.sh /build.sh
+RUN chmod +x /build.sh && \
+    /build.sh && \
+    rm -f /build.sh && \
+    rm -rf ${PROJECT_TEMPLATE_DIR}
+# Set the working directory to the default devbox user's project directory
+WORKDIR /home/${DEFAULT_DEVBOX_USER}/project

--- a/runtime-images/languages/java/openjdk8/build.sh
+++ b/runtime-images/languages/java/openjdk8/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+L10N=${L10N:-en_US}
+DEFAULT_DEVBOX_USER=${DEFAULT_DEVBOX_USER:-devbox}
+PROJECT_TEMPLATE_DIR=${PROJECT_TEMPLATE_DIR:-/project-template}
+
+if ! id -u "$DEFAULT_DEVBOX_USER" &>/dev/null; then
+  echo "User $DEFAULT_DEVBOX_USER does not exist"
+  exit 1
+fi
+
+TARGET_DIR="/home/$DEFAULT_DEVBOX_USER/project"
+mkdir -p "$TARGET_DIR"
+
+if [ -f "$PROJECT_TEMPLATE_DIR/README.$L10N.md" ]; then
+  echo "README $PROJECT_TEMPLATE_DIR/README.$L10N.md exists. Copying to $TARGET_DIR/README.md"
+  cp "$PROJECT_TEMPLATE_DIR/README.$L10N.md" "$TARGET_DIR/README.md"
+else
+  echo "README $PROJECT_TEMPLATE_DIR/README.$L10N.md does not exist. Skipping copy."
+fi
+
+DOCS_DIR=${DOCS_DIR:-/usr/share/devbox/docs}
+if [ -f "$DOCS_DIR/README.s6-user-guide.$L10N.md" ]; then
+  cp "$DOCS_DIR/README.s6-user-guide.$L10N.md" "$TARGET_DIR/README.s6-user-guide.md"
+elif [ -f "$DOCS_DIR/README.s6-user-guide.en_US.md" ]; then
+  cp "$DOCS_DIR/README.s6-user-guide.en_US.md" "$TARGET_DIR/README.s6-user-guide.md"
+fi
+
+cp -R "${PROJECT_TEMPLATE_DIR}/." "$TARGET_DIR/"
+rm -f "$TARGET_DIR/README.en_US.md" "$TARGET_DIR/README.zh_CN.md" || true
+
+if [ -f "$TARGET_DIR/entrypoint.sh" ]; then
+  chmod +x "$TARGET_DIR/entrypoint.sh"
+fi
+
+chown -R "$DEFAULT_DEVBOX_USER:$DEFAULT_DEVBOX_USER" "$TARGET_DIR"

--- a/runtime-images/languages/java/openjdk8/project-template/HelloWorld.java
+++ b/runtime-images/languages/java/openjdk8/project-template/HelloWorld.java
@@ -1,0 +1,28 @@
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+public class HelloWorld {
+    public static void main(String[] args) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
+        System.out.println("Server running at http://0.0.0.0:8080/");
+        server.createContext("/", new MyHandler());
+        server.setExecutor(null);
+        server.start();
+    }
+
+    static class MyHandler implements HttpHandler {
+        public void handle(HttpExchange exchange) throws IOException {
+            byte[] response = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            try (OutputStream output = exchange.getResponseBody()) {
+                output.write(response);
+            }
+        }
+    }
+}

--- a/runtime-images/languages/java/openjdk8/project-template/README.en_US.md
+++ b/runtime-images/languages/java/openjdk8/project-template/README.en_US.md
@@ -1,0 +1,52 @@
+# Java OpenJDK 8 Runtime Template
+
+This template provides a minimal Java HTTP service for the DevBox **OpenJDK 8** runtime. The image uses Eclipse Temurin OpenJDK `8u492-b09` and Apache Maven `3.9.16`.
+
+## Runtime Summary
+
+- Language/runtime version: `Eclipse Temurin OpenJDK 8u492-b09`
+- Build tool: `Apache Maven 3.9.16`
+- Base runtime image: `java-openjdk8`
+- Entrypoint script: `entrypoint.sh`
+- Default service port: `8080`
+
+## Template Files
+
+- `HelloWorld.java`: HTTP service using `com.sun.net.httpserver`
+- `entrypoint.sh`: compile-and-run script for development and production modes
+
+## Run in DevBox
+
+Run commands from `/home/devbox/project`.
+
+### Development mode
+
+```bash
+bash entrypoint.sh
+```
+
+### Production mode
+
+```bash
+bash entrypoint.sh production
+```
+
+Both modes compile the application with JDK 8 and start it with `java HelloWorld`.
+
+## Verify Service
+
+```bash
+curl http://127.0.0.1:8080
+```
+
+Expected output:
+
+```text
+Hello, World!
+```
+
+## Customization
+
+- Split `HelloWorld.java` into a package-based structure for larger projects.
+- Use the included Maven installation when dependency management is needed.
+- Replace the entrypoint commands when switching to a packaged JAR or framework-based application.

--- a/runtime-images/languages/java/openjdk8/project-template/README.zh_CN.md
+++ b/runtime-images/languages/java/openjdk8/project-template/README.zh_CN.md
@@ -1,0 +1,52 @@
+# Java OpenJDK 8 运行时模板
+
+该模板为 DevBox **OpenJDK 8** 运行时提供一个最小可运行的 Java HTTP 服务。镜像使用 Eclipse Temurin OpenJDK `8u492-b09` 和 Apache Maven `3.9.16`。
+
+## 运行时概览
+
+- 语言/运行时版本：`Eclipse Temurin OpenJDK 8u492-b09`
+- 构建工具：`Apache Maven 3.9.16`
+- 基础运行时镜像：`java-openjdk8`
+- 启动脚本：`entrypoint.sh`
+- 默认服务端口：`8080`
+
+## 模板文件
+
+- `HelloWorld.java`：基于 `com.sun.net.httpserver` 的 HTTP 服务
+- `entrypoint.sh`：开发和生产模式通用的编译运行脚本
+
+## 在 DevBox 中运行
+
+以下命令在 `/home/devbox/project` 目录执行。
+
+### 开发模式
+
+```bash
+bash entrypoint.sh
+```
+
+### 生产模式
+
+```bash
+bash entrypoint.sh production
+```
+
+两种模式都会使用 JDK 8 编译应用，然后通过 `java HelloWorld` 启动服务。
+
+## 验证服务
+
+```bash
+curl http://127.0.0.1:8080
+```
+
+预期输出：
+
+```text
+Hello, World!
+```
+
+## 自定义建议
+
+- 项目变大后建议将 `HelloWorld.java` 迁移为 package 目录结构。
+- 需要依赖管理时可直接使用镜像内置的 Maven。
+- 切换为可执行 JAR 或框架应用后，请同步更新 `entrypoint.sh`。

--- a/runtime-images/languages/java/openjdk8/project-template/entrypoint.sh
+++ b/runtime-images/languages/java/openjdk8/project-template/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$(id -u)" -eq 0 ] && [ "${DEVBOX_ENTRYPOINT_AS_DEVBOX:-1}" = "1" ] && id devbox >/dev/null 2>&1; then
+    export DEVBOX_ENTRYPOINT_AS_DEVBOX=0
+    SCRIPT_PATH=$(readlink -f "$0")
+    exec runuser -u devbox -- bash "$SCRIPT_PATH" "$@"
+fi
+
+app_env=${1:-development}
+build_target=${JAVA_BUILD_TARGET:-HelloWorld}
+
+if [ "$app_env" = "production" ] || [ "$app_env" = "prod" ]; then
+    echo "Production environment detected"
+else
+    echo "Development environment detected"
+fi
+
+javac "${build_target}.java"
+exec java "$build_target"

--- a/tests/runtime-conformance/README.md
+++ b/tests/runtime-conformance/README.md
@@ -42,6 +42,7 @@ Runtime-specific checks:
 | `languages/go/1.23.0` | exact Go version, matching `GOARCH`, prebuilt binary, `GOPROXY` for `zh_CN`, writable Go cache, root/devbox entrypoint order |
 | `languages/java/openjdk17` | Java/Javac 17, UTF-8, Maven mirror for `zh_CN`, root/devbox entrypoint order |
 | `languages/java/openjdk17-nginx-private` | Java/Javac 17, Maven mirror for `zh_CN`, Nginx 1.22.1 config/runtime paths, project proxy config, root/devbox entrypoint order |
+| `languages/java/openjdk8` | Temurin Java/Javac 1.8.0_492, UTF-8, Maven 3.9.16, Maven mirror for `zh_CN`, root/devbox entrypoint order |
 | `languages/net/8.0` | .NET 8 prefix, Tencent NuGet mirror for `zh_CN`, no `nuget.org` or unreachable Azure China source for `zh_CN`, root/devbox entrypoint order |
 | `languages/net/10.0` | .NET 10 prefix, Tencent NuGet mirror for `zh_CN`, no `nuget.org` or unreachable Azure China source for `zh_CN`, root/devbox entrypoint order |
 | `languages/node.js/18` | Node 18, npm/yarn/pnpm, npm mirror for `zh_CN`, root/devbox entrypoint order |

--- a/tests/runtime-conformance/run.sh
+++ b/tests/runtime-conformance/run.sh
@@ -475,13 +475,22 @@ check_python_runtime() {
 }
 
 check_java_runtime() {
+  local expected_version="$1"
   assert_command java
   assert_command javac
-  javac --version | grep 'javac 17' >/dev/null || fail "javac is not 17"
-  java -version 2>&1 | grep '17' >/dev/null || fail "java is not 17"
+  javac -version 2>&1 | grep "javac $expected_version" >/dev/null || fail "javac is not $expected_version"
+  java -version 2>&1 | grep "$expected_version" >/dev/null || fail "java is not $expected_version"
   java -XshowSettings:properties -version 2>&1 | grep 'file.encoding = UTF-8' >/dev/null || fail "Java file.encoding is not UTF-8"
   assert_file "$PROJECT_DIR/HelloWorld.java"
   require_zh_maven_mirror
+}
+
+check_java8_runtime() {
+  check_java_runtime 1.8.0_492
+  assert_command mvn
+  java -version 2>&1 | grep 'Temurin' >/dev/null || fail "Java vendor is not Temurin"
+  mvn -version | grep 'Apache Maven 3.9.16' >/dev/null || fail "Maven is not 3.9.16"
+  mvn -version | grep 'Java version: 1.8.0_492' >/dev/null || fail "Maven is not using Java 1.8.0_492"
 }
 
 check_c_runtime() {
@@ -526,7 +535,7 @@ check_nginx_runtime() {
 }
 
 check_java_nginx_private_runtime() {
-  check_java_runtime
+  check_java_runtime 17
   check_nginx_runtime
   assert_file "$PROJECT_DIR/nginx.conf"
 }
@@ -625,7 +634,10 @@ check_runtime_specifics() {
       check_go_runtime 1.23.0
       ;;
     languages/java/openjdk17)
-      check_java_runtime
+      check_java_runtime 17
+      ;;
+    languages/java/openjdk8)
+      check_java8_runtime
       ;;
     languages/java/openjdk17-nginx-private)
       check_java_nginx_private_runtime

--- a/tests/runtime-smoke/languages/java/openjdk8/smoke.sh
+++ b/tests/runtime-smoke/languages/java/openjdk8/smoke.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -eu
+
+project_dir=/home/devbox/project
+
+if [ ! -d "$project_dir" ]; then
+  echo "Missing project dir: $project_dir" >&2
+  exit 1
+fi
+
+set +u
+# shellcheck disable=SC1091
+[ -f /etc/profile ] && . /etc/profile || true
+if [ -d /etc/profile.d ]; then
+  for f in /etc/profile.d/*.sh; do
+    # shellcheck disable=SC1090
+    [ -r "$f" ] && . "$f" || true
+  done
+fi
+# shellcheck disable=SC1091
+[ -f /home/devbox/.bashrc ] && . /home/devbox/.bashrc || true
+set -u
+
+if [ "${SMOKE_DEBUG:-}" = "1" ]; then
+  echo "SMOKE_DEBUG=1"
+  echo "user=$(id -un) uid=$(id -u) gid=$(id -g)"
+  echo "HOME=$HOME"
+  echo "JAVA_HOME=${JAVA_HOME:-}"
+  echo "MAVEN_HOME=${MAVEN_HOME:-}"
+  echo "PATH=$PATH"
+  for cmd in java javac mvn curl; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+      echo "cmd:$cmd=$(command -v "$cmd")"
+    else
+      echo "cmd:$cmd=missing"
+    fi
+  done
+fi
+
+cd "$project_dir"
+
+javac -version 2>&1 | grep -q 'javac 1.8.0_492'
+java -version 2>&1 | grep -q '1.8.0_492'
+java -version 2>&1 | grep -q 'Temurin'
+java -XshowSettings:properties -version 2>&1 | grep -q 'file.encoding = UTF-8'
+mvn -version | grep -q 'Apache Maven 3.9.16'
+mvn -version | grep -q 'Java version: 1.8.0_492'
+
+for required_file in HelloWorld.java README.md; do
+  if [ ! -f "$project_dir/$required_file" ]; then
+    echo "Missing $required_file in $project_dir" >&2
+    exit 1
+  fi
+done
+
+entrypoint="$project_dir/entrypoint.sh"
+if [ ! -x "$entrypoint" ]; then
+  echo "Missing executable entrypoint.sh in $project_dir" >&2
+  exit 1
+fi
+
+cleanup_entrypoint() {
+  if [ -n "${pid:-}" ] && kill -0 "$pid" >/dev/null 2>&1; then
+    kill "$pid" >/dev/null 2>&1 || true
+    wait "$pid" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup_entrypoint EXIT INT TERM
+
+( cd "$project_dir" && bash "$entrypoint" ) >/tmp/entrypoint.log 2>&1 &
+pid=$!
+deadline=$((SECONDS + 60))
+while ! curl -fsS http://127.0.0.1:8080 >/tmp/smoke-response 2>/dev/null; do
+  if ! kill -0 "$pid" >/dev/null 2>&1; then
+    echo "entrypoint exited early" >&2
+    echo "---- entrypoint log ----" >&2
+    cat /tmp/entrypoint.log >&2 || true
+    exit 1
+  fi
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "entrypoint did not serve HTTP on port 8080 within 60 seconds" >&2
+    echo "---- entrypoint log ----" >&2
+    cat /tmp/entrypoint.log >&2 || true
+    exit 1
+  fi
+  sleep 2
+done
+
+grep -q 'Hello, World!' /tmp/smoke-response
+
+cleanup_entrypoint
+trap - EXIT INT TERM
+
+echo "ok"


### PR DESCRIPTION
## What changed

- Add the `languages/java/openjdk8` base and runtime images.
- Install Eclipse Temurin OpenJDK `8u492-b09` and Apache Maven `3.9.16` from pinned, checksum-verified archives for both amd64 and arm64.
- Add a Java 8-compatible HTTP project template with localized English and Chinese documentation.
- Add runtime smoke and conformance coverage for exact Java/Maven versions, UTF-8, Maven localization, project permissions, entrypoint behavior, HTTP readiness, and both architectures.

## Why

The repository currently provides OpenJDK 17 but no Java 8 runtime template. Debian 12 does not package an OpenJDK 8 JDK directly, and installing Debian's Maven package would pull in the default OpenJDK 17 runtime. This change installs a pinned multi-architecture Temurin JDK and a standalone Maven distribution so the resulting image consistently uses Java 8.

## Developer impact

The runtime is discovered as `languages/java/openjdk8` and published as `java-openjdk8`. It exposes `JAVA_HOME=/usr/lib/jvm/java-8-openjdk`, `MAVEN_HOME=/opt/maven`, and a PATH that prioritizes the Java 8 and Maven binaries. Chinese-localized images configure the existing Aliyun Maven mirror convention.

## Validation

- Local shell syntax, Python planner compilation, `git diff --check`, build planner, and conformance planner passed.
- Local en_US/arm64 and zh_CN/arm64 runtime builds, smoke tests, and full conformance passed.
- Fork release build, tag `jdk8-ci-e22682d`, target `runtime/lang/java/openjdk8`, profile `release`, both l10n values and both architectures: https://github.com/GodBlf/devbox-runtime/actions/runs/29303160464
- Fork smoke, en_US on amd64 and arm64: https://github.com/GodBlf/devbox-runtime/actions/runs/29303586047
- Fork conformance, en_US/zh_CN on amd64/arm64: https://github.com/GodBlf/devbox-runtime/actions/runs/29303585385

The fork CI runs used temporary workflow-only normalization for the mixed-case fork owner (`GodBlf` to `godblf`) when addressing GHCR. Those changes were removed after validation; this PR contains no workflow diff. The upstream `labring-actions` owner is already lowercase and is not affected by the fork limitation.
